### PR TITLE
Fix GET /movies/:id error handling

### DIFF
--- a/internal/delivery/gin/movie_handler.go
+++ b/internal/delivery/gin/movie_handler.go
@@ -22,13 +22,17 @@ func NewMovieHandler(r *gin.Engine, usecase *usecase.MovieUsecase) {
 	r.GET("/movies/:id", func(c *gin.Context) {
 		id, err := strconv.Atoi(c.Param("id"))
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
 
 		movie, err := usecase.GetMovieByID(id)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			if err.Error() == "movie not found" {
+				c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+			} else {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			}
 			return
 		}
 


### PR DESCRIPTION
## Summary
- ensure invalid movie ID returns `400 Bad Request`
- return `404 Not Found` when the movie doesn't exist

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68472148f5fc83339762fb576ca10be2