### PR TITLE
Prevent duplicate movie titles

### DIFF
--- a/internal/delivery/gin/movie_handler.go
+++ b/internal/delivery/gin/movie_handler.go
@@ -46,7 +46,11 @@ func NewMovieHandler(r *gin.Engine, usecase *usecase.MovieUsecase) {
 			return
 		}
 		if err := usecase.CreateMovie(&movie); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			if err.Error() == "movie title already exists" {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			} else {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			}
 			return
 		}
 		c.JSON(http.StatusCreated, movie)

--- a/internal/domain/movie_interface.go
+++ b/internal/domain/movie_interface.go
@@ -3,6 +3,7 @@ package domain
 type MovieRepository interface {
 	GetAll() ([]Movie, error)
 	GetByID(id int) (*Movie, error)
+	GetByTitle(title string) (*Movie, error)
 	Create(movie *Movie) error
 	Update(id int, movie *Movie) error
 	Delete(id int) error

--- a/internal/repository/gorm_movie_repository.go
+++ b/internal/repository/gorm_movie_repository.go
@@ -43,6 +43,17 @@ func (r *GORMMovieRepository) GetByID(id int) (*domain.Movie, error) {
 	return &movie, nil
 }
 
+func (r *GORMMovieRepository) GetByTitle(title string) (*domain.Movie, error) {
+	var movie domain.Movie
+	if err := r.db.Where("title = ?", title).First(&movie).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("movie not found")
+		}
+		return nil, err
+	}
+	return &movie, nil
+}
+
 func (r *GORMMovieRepository) Create(movie *domain.Movie) error {
 	return r.db.Create(movie).Error
 }

--- a/internal/repository/in_memory_movie_repository.go
+++ b/internal/repository/in_memory_movie_repository.go
@@ -31,6 +31,16 @@ func (r *InMemoryMovieRepository) GetByID(id int) (*domain.Movie, error) {
 	return &movie, nil
 }
 
+func (r *InMemoryMovieRepository) GetByTitle(title string) (*domain.Movie, error) {
+	for _, movie := range r.data {
+		if movie.Title == title {
+			m := movie
+			return &m, nil
+		}
+	}
+	return nil, errors.New("movie not found")
+}
+
 func (r *InMemoryMovieRepository) Create(movie *domain.Movie) error {
 	if movie.ID == 0 {
 		movie.ID = r.nextID

--- a/internal/repository/postgres_movie_repository.go
+++ b/internal/repository/postgres_movie_repository.go
@@ -58,6 +58,18 @@ func (r *PostgresMovieRepository) GetByID(id int) (*domain.Movie, error) {
 	return &m, nil
 }
 
+func (r *PostgresMovieRepository) GetByTitle(title string) (*domain.Movie, error) {
+	var m domain.Movie
+	row := r.db.QueryRow("SELECT id, title, director, genre, year FROM movies WHERE title=$1", title)
+	if err := row.Scan(&m.ID, &m.Title, &m.Director, &m.Genre, &m.Year); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("movie not found")
+		}
+		return nil, err
+	}
+	return &m, nil
+}
+
 func (r *PostgresMovieRepository) Create(movie *domain.Movie) error {
 	return r.db.QueryRow(
 		"INSERT INTO movies (title, director, genre, year) VALUES ($1, $2, $3, $4) RETURNING id",

--- a/internal/repository/sqlserver_movie_repository.go
+++ b/internal/repository/sqlserver_movie_repository.go
@@ -61,6 +61,18 @@ func (r *SQLServerMovieRepository) GetByID(id int) (*domain.Movie, error) {
 	return &m, nil
 }
 
+func (r *SQLServerMovieRepository) GetByTitle(title string) (*domain.Movie, error) {
+	var m domain.Movie
+	row := r.db.QueryRow("SELECT id, title, director, genre, year FROM movies WHERE title = @p1", title)
+	if err := row.Scan(&m.ID, &m.Title, &m.Director, &m.Genre, &m.Year); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("movie not found")
+		}
+		return nil, err
+	}
+	return &m, nil
+}
+
 func (r *SQLServerMovieRepository) Create(movie *domain.Movie) error {
 	return r.db.QueryRow(
 		"INSERT INTO movies (title, director, genre, year) OUTPUT INSERTED.id VALUES (@p1, @p2, @p3, @p4)",

--- a/internal/usecase/movie_usecase.go
+++ b/internal/usecase/movie_usecase.go
@@ -1,6 +1,7 @@
 package usecase
 
 import (
+	"fmt"
 	"github.com/pedro-vasconcelos-dev/movies-api/internal/domain"
 )
 
@@ -17,6 +18,13 @@ func (u *MovieUsecase) GetMovieByID(id int) (*domain.Movie, error) {
 }
 
 func (u *MovieUsecase) CreateMovie(movie *domain.Movie) error {
+	existing, err := u.Repo.GetByTitle(movie.Title)
+	if err == nil && existing != nil {
+		return fmt.Errorf("movie title already exists")
+	}
+	if err != nil && err.Error() != "movie not found" {
+		return err
+	}
 	return u.Repo.Create(movie)
 }
 


### PR DESCRIPTION
## Summary
- extend repository interface with `GetByTitle`
- implement title lookup for all repositories
- validate duplicate titles in MovieUsecase
- return proper HTTP error when title already exists

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68472c9abee0833383c773256c2cf6f8